### PR TITLE
Remove void typehint to support php 7.0

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -427,8 +427,9 @@ class DataCompiler
 
     /**
      * @param array $primaryKeys
+     * @return void
      */
-    private function updatePostgresSequence(array $primaryKeys): void
+    private function updatePostgresSequence(array $primaryKeys)
     {
         if (Util::isRunningOnPostgresql($this->getFactory())) {
             $tableName = $this->getFactory()->getRootTableRegistry()->getTable();


### PR DESCRIPTION
Void typehints are not supported in php 7.0 but the package composer.json declares php 7.0 as the minimum php version. Therefore I removed the `void` typehint which would lead to breaking code in php 7.0.

Maybe it would be a good idea to test against php 7.0 as well.