### PR TITLE
Avoid using deprecated accessor (`uuid` as prop)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2",
         "cakephp/cakephp": "^4.0",
-        "fakerphp/faker": "^1.13",
+        "fakerphp/faker": "^1.15",
         "vierge-noire/cakephp-test-suite-light": "^2.1"
     },
     "require-dev": {

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -364,7 +364,6 @@ abstract class BaseFactory
      */
     protected function persistMany(array $entities)
     {
-        /** @phpstan-ignore-next-line */
         return $this->getTable()->saveManyOrFail($entities, $this->getSaveOptions());
     }
 

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -445,7 +445,7 @@ class DataCompiler
         switch ($columnType) {
             case 'uuid':
             case 'string':
-                $res = $this->getFactory()->getFaker()->uuid;
+                $res = $this->getFactory()->getFaker()->uuid();
                 break;
             case 'biginteger':
                 $res = mt_rand(0, intval('9223372036854775807'));


### PR DESCRIPTION
ref: #78 

FakerPHP/Faker now released v1.15.
see: 
https://github.com/FakerPHP/Faker/blob/v1.15.0/src/Faker/Generator.php
and https://github.com/FakerPHP/Faker/commit/89c6201c74db25fa759ff16e78a4d8f32547770e

As mentioned at https://github.com/vierge-noire/cakephp-fixture-factories/pull/78#issuecomment-842223018, there is now official support for the intended accessors.

I haven't been able to track the overall fix yet, but I sent another request, including an update to the dependent version specification.

Check out the contents, and pull this in if you like!

This nice tool is always helping me, thanks!