### PR TITLE
 #134 Portable fixture factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.2",
-        "cakephp/cakephp": "^4.0",
+        "cakephp/orm": "^4.0",
         "fakerphp/faker": "^1.15",
         "vierge-noire/cakephp-test-suite-light": "^2.1"
     },

--- a/docs/factories.md
+++ b/docs/factories.md
@@ -135,8 +135,6 @@ You may save in your configuration file, under the key `TestFixtureGlobalBehavio
 ```
 
 Note that even if the behavior is located in a plugin, you should, according to CakePHP conventions, provide the name of the behavior only. Provide `BehaviorName` and not `SomeVendor/WithPluginName.BehaviorName`.
-
-The static method `makeWithModelEvents` is now deprecated and will be removed soon.
  
 ### Namespace
  

--- a/src/Command/PersistCommand.php
+++ b/src/Command/PersistCommand.php
@@ -193,7 +193,7 @@ class PersistCommand extends Command
     {
         ConnectionManager::alias(
             $connection,
-            $factory->getRootTableRegistry()->getConnection()->configName()
+            $factory->getTable()->getConnection()->configName()
         );
     }
 

--- a/src/Factory/AssociationBuilder.php
+++ b/src/Factory/AssociationBuilder.php
@@ -132,7 +132,7 @@ class AssociationBuilder
         }
 
         $thisFactoryRegistryName = $this->getTable()->getRegistryAlias();
-        $associatedFactoryTable = $associatedFactory->getRootTableRegistry();
+        $associatedFactoryTable = $associatedFactory->getTable();
 
         $associatedAssociationName = Inflector::singularize($thisFactoryRegistryName);
 
@@ -281,6 +281,6 @@ class AssociationBuilder
      */
     public function getTable(): Table
     {
-        return $this->getFactory()->getRootTableRegistry();
+        return $this->getFactory()->getTable();
     }
 }

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -172,25 +172,6 @@ abstract class BaseFactory
     }
 
     /**
-     * Method to apply all model event listeners, both in the
-     * related TableRegistry as well as in the Behaviors
-     * This is vey bad practice. The main purpose of the factory is to
-     * generate data as fast and transparently as possible.
-     *
-     * @deprecated Use instead $this->listeningToBehaviors and $this->listeningToModelEvents
-     * @param array|callable|null|int $makeParameter Injected data
-     * @param int                     $times Number of entities created
-     * @return static
-     */
-    public static function makeWithModelEvents($makeParameter = [], $times = 1): BaseFactory
-    {
-        $factory = static::make($makeParameter, $times);
-        $factory->withModelEvents = true;
-
-        return $factory;
-    }
-
-    /**
      * @param array|\Cake\Datasource\EntityInterface|\Cake\Datasource\EntityInterface[] $data Injected data
      * @return static
      */

--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -154,9 +154,21 @@ abstract class BaseFactory
      */
     protected function setUp(BaseFactory $factory, int $times): void
     {
+        $factory->initialize();
         $factory->setTimes($times);
         $factory->setDefaultTemplate();
         $factory->getDataCompiler()->collectAssociationsFromDefaultTemplate();
+    }
+
+    /**
+     * This method may be used to define associations
+     * missing in your model but useful to build factories
+     *
+     * @return void
+     */
+    protected function initialize(): void
+    {
+        // Add logic prior to generating the default template.
     }
 
     /**
@@ -297,20 +309,10 @@ abstract class BaseFactory
     public function getTable(): Table
     {
         if ($this->withModelEvents) {
-            return $this->getRootTableRegistry();
+            return TableRegistry::getTableLocator()->get($this->getRootTableRegistryName());
         } else {
             return $this->getEventCompiler()->getTable();
         }
-    }
-
-    /**
-     * The default table registry, the CakePHP one
-     *
-     * @return \Cake\ORM\Table
-     */
-    public function getRootTableRegistry(): Table
-    {
-        return TableRegistry::getTableLocator()->get($this->getRootTableRegistryName());
     }
 
     /**

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -60,23 +60,23 @@ trait FactoryAwareTrait
     /**
      * Returns the factory file name
      *
-     * @param  string $name [description]
+     * @param  string $name Name of the model or table
      * @return string       [description]
      */
     public function getFactoryFileName(string $name): string
     {
-        return $this->getFactoryNameFromModelName($name) . '.php';
+        return str_replace('\\', DIRECTORY_SEPARATOR, $this->getFactoryNameFromModelName($name)) . '.php';
     }
 
     /**
      * Return the name of the factory from a model name
      *
-     * @param string $modelName Name of the model
+     * @param string $modelName Name of the model or table
      * @return string
      */
     public static function getFactoryNameFromModelName(string $modelName): string
     {
-        return Inflector::singularize(ucfirst($modelName)) . 'Factory';
+        return str_replace('/', '\\', Inflector::classify($modelName)) . 'Factory';
     }
 
     /**

--- a/src/Factory/UniquenessJanitor.php
+++ b/src/Factory/UniquenessJanitor.php
@@ -65,7 +65,7 @@ class UniquenessJanitor
         $propertyIsUnique = function (string $property) use ($factory): bool {
             return in_array($property, array_merge(
                 $factory->getUniqueProperties(),
-                (array)$factory->getRootTableRegistry()->getPrimaryKey()
+                (array)$factory->getTable()->getPrimaryKey()
             ));
         };
 

--- a/tests/Factory/CityFactory.php
+++ b/tests/Factory/CityFactory.php
@@ -30,6 +30,13 @@ class CityFactory extends BaseFactory
         'virtual_unique_stamp',
     ];
 
+    protected function initialize(): void
+    {
+        $this->getTable()->hasMany('TableWithoutModel', [
+            'foreignKey' => 'foreign_key',
+        ]);
+    }
+
     protected function getRootTableRegistryName(): string
     {
         return 'Cities';

--- a/tests/Factory/TableWithoutModelFactory.php
+++ b/tests/Factory/TableWithoutModelFactory.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use Faker\Generator;
+
+/**
+ * Class TableWithoutModelFactory
+ *
+ * @method \Cake\ORM\Entity getEntity()
+ * @method \Cake\ORM\Entity[] getEntities()
+ * @method \Cake\ORM\Entity|\Cake\ORM\Entity[] persist()
+ * @method static \Cake\ORM\Entity get(mixed $primaryKey, array $options = [])
+ */
+class TableWithoutModelFactory extends BaseFactory
+{
+    /**
+     * Defines the Table Registry used to generate entities with
+     *
+     * @return string
+     */
+    protected function getRootTableRegistryName(): string
+    {
+        return 'table_without_model';
+    }
+
+    /**
+     * Defines the default values of you factory. Useful for
+     * not nullable fields.
+     * Use the patchData method to set the field values.
+     * You may use methods of the factory here
+     *
+     * @return void
+     */
+    protected function setDefaultTemplate(): void
+    {
+        $this->setDefaultData(function (Generator $faker) {
+            return [
+                'name' => $faker->text(120),
+                'foreign_key' => $faker->randomNumber(),
+                'binding_key' => $faker->randomNumber(),
+                'country_id' => $faker->randomNumber(),
+            ];
+        });
+    }
+}

--- a/tests/TestApp/config/Migrations/20211022100000_table_without_model_migration.php
+++ b/tests/TestApp/config/Migrations/20211022100000_table_without_model_migration.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+use Migrations\AbstractMigration;
+
+class TableWithoutModelMigration extends AbstractMigration
+{
+    public function up()
+    {
+        $this->table('table_without_model')
+            ->addPrimaryKey(['id'])
+            ->addColumn('name', 'string', [
+                'limit' => 128,
+                'null' => false,
+            ])
+            ->addColumn('foreign_key', 'integer', [
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('binding_key', 'integer', [
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addColumn('country_id', 'integer', [
+                'limit' => 11,
+                'null' => false,
+            ])
+            ->addTimestamps('created', 'modified')
+            ->save();
+    }
+
+    public function down()
+    {
+        $this->table('table_without_model')->drop();
+    }
+}

--- a/tests/TestApp/src/Model/Table/CitiesTable.php
+++ b/tests/TestApp/src/Model/Table/CitiesTable.php
@@ -24,12 +24,8 @@ class CitiesTable extends Table
     {
         $this->addBehavior('Timestamp');
 
-        $this->addAssociations([
-            'belongsTo' => [
-                'Country' => [
-                    'className' => 'Countries',
-                ],
-            ],
+        $this->belongsTo('Country', [
+            'className' => 'Countries',
         ]);
 
         $this->hasMany('Addresses');

--- a/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
@@ -20,6 +20,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Hash;
 use CakephpFixtureFactories\Error\AssociationBuilderException;
+use CakephpFixtureFactories\ORM\FactoryTableRegistry;
 use CakephpFixtureFactories\Test\Factory\AddressFactory;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;
@@ -684,17 +685,13 @@ class BaseFactoryAssociationsTest extends TestCase
 
     public function testCompileEntityForToOneAssociation()
     {
-        TableRegistry::getTableLocator()->get('Cities')->addAssociations([
-            'belongsTo' => [
-                'Countries'
-            ],
-        ]);
+        CityFactory::make()->getTable()->belongsTo('Countries');
         $name = 'FooCountry';
         $factories = [
-            CityFactory::makeWithModelEvents()->with('Country', compact('name')),
-            CityFactory::makeWithModelEvents()->with('Countries', compact('name')),
-            CityFactory::makeWithModelEvents()->with('Country')->with('Countries', compact('name')),
-            CityFactory::makeWithModelEvents()->with('Country', ['name' => 'Foo'])->with('Countries', compact('name')),
+            CityFactory::make()->with('Country', compact('name')),
+            CityFactory::make()->with('Countries', compact('name')),
+            CityFactory::make()->with('Country')->with('Countries', compact('name')),
+            CityFactory::make()->with('Country', ['name' => 'Foo'])->with('Countries', compact('name')),
         ];
 
         foreach ($factories as $factory) {
@@ -703,6 +700,7 @@ class BaseFactoryAssociationsTest extends TestCase
             $this->assertSame(null, $entity->get('countries'));
         }
 
-        TableRegistry::getTableLocator()->clear();
+        FactoryTableRegistry::getTableLocator()->clear();
+        $this->assertSame(false, CityFactory::make()->getTable()->hasAssociation('Countries'));
     }
 }

--- a/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
@@ -30,7 +30,6 @@ use CakephpFixtureFactories\Test\Factory\CustomerFactory;
 use Exception;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
-use TestApp\Model\Entity\Author;
 use TestApp\Model\Entity\City;
 use TestApp\Model\Entity\Country;
 use TestApp\Model\Entity\PremiumAuthor;
@@ -335,7 +334,7 @@ class BaseFactoryAssociationsTest extends TestCase
                 return $q->order('Authors.name');
             })
             ->first();
-        
+
         $this->assertSame($name1, $article->authors[0]->name);
         $this->assertSame($name2, $article->authors[1]->name);
     }
@@ -599,7 +598,7 @@ class BaseFactoryAssociationsTest extends TestCase
         $this->assertSame(4, count($country->cities));
         $this->assertSame(4, CityFactory::count());
 
-        if (CountryFactory::make()->getRootTableRegistry()->getConnection()->config()['driver'] === Postgres::class) {
+        if (CountryFactory::make()->getTable()->getConnection()->config()['driver'] === Postgres::class) {
             $this->assertSame($city1, CityFactory::get(1)->name);
             $this->assertSame($city2, CityFactory::get(2)->name);
             $this->assertSame($street1, AddressFactory::get(1)->street);
@@ -620,7 +619,6 @@ class BaseFactoryAssociationsTest extends TestCase
         $factory = CountryFactory::make()
             ->with('Cities')
             ->with('VirtualCities');
-
 
         $country = $factory->getEntity();
         $this->assertIsString($country->cities[0]->name);
@@ -686,7 +684,7 @@ class BaseFactoryAssociationsTest extends TestCase
 
     public function testCompileEntityForToOneAssociation()
     {
-        CityFactory::make()->getRootTableRegistry()->addAssociations([
+        TableRegistry::getTableLocator()->get('Cities')->addAssociations([
             'belongsTo' => [
                 'Countries'
             ],

--- a/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
+++ b/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) 2020 Juan Pablo Ramirez and Nicolas Masson
+ * @link          https://webrider.de/
+ * @since         2.5
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace CakephpFixtureFactories\Test\TestCase\Factory;
+
+use Cake\Core\Configure;
+use Cake\ORM\Entity;
+use Cake\TestSuite\TestCase;
+use CakephpFixtureFactories\ORM\FactoryTableRegistry;
+use CakephpFixtureFactories\Test\Factory\AddressFactory;
+use CakephpFixtureFactories\Test\Factory\ArticleFactory;
+use CakephpFixtureFactories\Test\Factory\AuthorFactory;
+use CakephpFixtureFactories\Test\Factory\CityFactory;
+use CakephpFixtureFactories\Test\Factory\CountryFactory;
+use CakephpFixtureFactories\Test\Factory\TableWithoutModelFactory;
+use TestApp\Model\Entity\Address;
+use TestApp\Model\Entity\Country;
+use function count;
+
+class BaseFactoryLoadAssociationsInInitializeTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Configure::delete('TestFixtureNamespace');
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        // Clear the association created on the fly
+        FactoryTableRegistry::getTableLocator()->clear();
+    }
+
+    public function testLoadAssociationInInitialize_Get_Entity()
+    {
+        $name = 'Foo';
+        $city = CityFactory::make()
+            ->with('TableWithoutModel', compact('name'))
+            ->getEntity();
+
+        $this->assertSame(1, count($city->get('table_without_model')));
+        $tableWithoutModel = $city->get('table_without_model')[0];
+        $this->assertInstanceOf(Entity::class, $tableWithoutModel);
+        $this->assertSame($name, $tableWithoutModel->name);
+    }
+
+    public function testLoadAssociationInInitialize_Get_Entities()
+    {
+        $name = 'Foo';
+        $n = 2;
+        $city = CityFactory::make()
+            ->with("TableWithoutModel[$n]", compact('name'))
+            ->getEntity();
+
+        $this->assertSame($n, count($city->get('table_without_model')));
+        foreach ($city->get('table_without_model') as $entity) {
+            $this->assertInstanceOf(Entity::class, $entity);
+            $this->assertSame($name, $entity->name);
+        }
+    }
+
+    public function testLoadAssociationInInitialize_Persist()
+    {
+        $name = 'Foo';
+        $city = CityFactory::make()
+            ->with('TableWithoutModel', compact('name'))
+            ->persist();
+
+        $this->assertSame(1, count($city->get('table_without_model')));
+        $tableWithoutModel = $city->get('table_without_model')[0];
+        $this->assertInstanceOf(Entity::class, $tableWithoutModel);
+        $this->assertSame($name, $tableWithoutModel->name);
+        $this->assertSame($city->id, $tableWithoutModel->get('foreign_key'));
+        $this->assertSame(1, TableWithoutModelFactory::count());
+        $this->assertSame(1, CountryFactory::count());
+    }
+
+    public function testLoadAssociationOnTheFly_Has_One_Persist()
+    {
+        $factory = CityFactory::make();
+        $factory->getTable()->hasOne('HasOneTableWithoutModel', [
+            'className' => 'TableWithoutModel',
+            'foreignKey' => 'foreign_key',
+        ]);
+
+        $name = 'Foo';
+        $city = $factory
+            ->with('HasOneTableWithoutModel', compact('name'))
+            ->persist();
+
+        $hasOneTableWithoutModel = $city->get('has_one_table_without_model');
+        $this->assertInstanceOf(Entity::class, $hasOneTableWithoutModel);
+        $this->assertSame($name, $hasOneTableWithoutModel->name);
+        $this->assertSame($city->id, $hasOneTableWithoutModel->get('foreign_key'));
+        $this->assertSame(1, TableWithoutModelFactory::count());
+        $this->assertSame(1, CountryFactory::count());
+    }
+
+    public function dataForClassName(): array
+    {
+        return [['TableWithoutModel'], ['table_without_model']];
+    }
+
+    /** @dataProvider dataForClassName */
+    public function testLoadAssociationOnTheFly_HasMany_With_Magic_Persist($className)
+    {
+        $factory = CityFactory::make();
+        $factory->getTable()->hasMany('Addresses', compact('className'));
+
+        $name = 'Foo';
+        $n = 2;
+        $city = $factory->with("Addresses[$n]", compact('name'))->persist();
+
+        $addresses = $city->addresses;
+        foreach ($addresses as $address) {
+            $this->assertInstanceOf(Entity::class, $address);
+            $this->assertNotInstanceOf(Address::class, $address);
+            $this->assertSame($name, $address->get('name'));
+            $this->assertSame($city->id, $address->city_id);
+        }
+        $this->assertSame(1, CityFactory::count());
+        $this->assertSame(0, AddressFactory::count());
+        $this->assertSame($n, TableWithoutModelFactory::count());
+    }
+
+    /** @dataProvider dataForClassName */
+    public function testLoadAssociationOnTheFly_BelongsTo_With_Magic_Persist($className)
+    {
+        // Because of a foreign key constrain at the DB level, a country with id $city->country_id
+        // must be in the DB
+        $country = CountryFactory::make()->persist();
+
+        $factory = CityFactory::make();
+        $factory->getTable()->belongsTo('Country', compact('className'));
+
+        $name = 'Foo';
+        $id = $country->id;
+        $city = $factory->with("Country", compact('id', 'name'))->persist();
+
+        $country = $city->country;
+        $this->assertInstanceOf(Entity::class, $country);
+        $this->assertNotInstanceOf(Country::class, $country);
+        $this->assertSame($name, $country->name);
+        $this->assertSame(1, CountryFactory::count());
+        $this->assertSame(1, CityFactory::count());
+        $this->assertSame(1, TableWithoutModelFactory::count());
+    }
+
+    /** @dataProvider dataForClassName */
+    public function testLoadAssociationOnTheFly_BelongsToMany_With_Magic_Persist($className)
+    {
+        $factory = AuthorFactory::make();
+        $factory->getTable()->belongsToMany('ParallelArticles', [
+            'className' => $className,
+            'joinTable' => 'articles_authors',
+            'targetForeignKey' => 'article_id'
+        ]);
+
+        $name = 'Foo';
+        $n = 2;
+        $author = $factory->with("ParallelArticles[$n]", compact('name'))->persist();
+
+        $articles = $author->get('parallel_articles');
+        $this->assertSame($n, count($articles));
+        foreach ($articles as $article) {
+            $this->assertInstanceOf(Entity::class, $article);
+            $this->assertNotInstanceOf(ArticleFactory::class, $article);
+            $this->assertSame($name, $article->get('name'));
+        }
+        $this->assertSame(1, AuthorFactory::count());
+        $this->assertSame($n, TableWithoutModelFactory::count());
+
+        $author = AuthorFactory::find()->contain('ParallelArticles')->firstOrFail();
+        $articles = $author->get('parallel_articles');
+        $this->assertSame($n, count($articles));
+        foreach ($articles as $article) {
+            $this->assertInstanceOf(Entity::class, $article);
+            $this->assertNotInstanceOf(ArticleFactory::class, $article);
+            $this->assertSame($name, $article->get('name'));
+        }
+    }
+
+    public function testLoadAssociationOnTheFly_Overwrite_Existing_Association_Persist()
+    {
+        $factory = CityFactory::make();
+        $this->assertTrue($factory->getTable()->hasAssociation('Addresses'));
+
+        $factory->getTable()->hasMany('Addresses', [
+            'className' => 'TableWithoutModel',
+            'foreignKey' => 'foreign_key',
+        ]);
+
+        $name = 'Foo';
+        $n = 2;
+        $city = $factory
+            ->with("Addresses[$n]", compact('name'))
+            ->persist();
+
+        $addresses = $city->addresses;
+        foreach ($addresses as $address) {
+            $this->assertInstanceOf(Entity::class, $address);
+            $this->assertNotInstanceOf(Address::class, $address);
+            $this->assertSame($name, $address->get('name'));
+            $this->assertSame($city->id, $address->get('foreign_key'));
+        }
+        $this->assertSame(1, CityFactory::count());
+        $this->assertSame(0, AddressFactory::count());
+        $this->assertSame($n, TableWithoutModelFactory::count());
+    }
+}

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -852,11 +852,7 @@ class BaseFactoryTest extends TestCase
     public function testSkipValidation()
     {
         $maxLength = CountriesTable::NAME_MAX_LENGTH;
-        $validator = new Validator();
-        $validator->maxLength('name', $maxLength);
-
         $CountriesTable = TableRegistry::getTableLocator()->get('Countries');
-
         $name = str_repeat('a', $maxLength + 1);
 
         $country = $CountriesTable->newEntity(compact('name'));
@@ -866,11 +862,6 @@ class BaseFactoryTest extends TestCase
         $country = CountryFactory::make(compact('name'))->getEntity();
         $this->assertFalse($country->hasErrors());
         $country = CountryFactory::make(compact('name'))->persist();
-        $this->assertInstanceOf(Country::class, $country);
-
-        $country = CountryFactory::makeWithModelEvents(compact('name'))->getEntity();
-        $this->assertFalse($country->hasErrors());
-        $country = CountryFactory::makeWithModelEvents(compact('name'))->persist();
         $this->assertInstanceOf(Country::class, $country);
     }
 

--- a/tests/TestCase/Factory/DataCompilerTest.php
+++ b/tests/TestCase/Factory/DataCompilerTest.php
@@ -17,7 +17,6 @@ namespace CakephpFixtureFactories\Test\TestCase\Factory;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use CakephpFixtureFactories\Error\PersistenceException;
-use CakephpFixtureFactories\Factory\BaseFactory;
 use CakephpFixtureFactories\Factory\DataCompiler;
 use CakephpFixtureFactories\Test\Factory\ArticleFactory;
 use CakephpFixtureFactories\Test\Factory\AuthorFactory;

--- a/tests/TestCase/Factory/EventCollectorTest.php
+++ b/tests/TestCase/Factory/EventCollectorTest.php
@@ -27,7 +27,6 @@ use CakephpFixtureFactories\Test\Factory\BillFactory;
 use CakephpFixtureFactories\Test\Factory\CityFactory;
 use CakephpFixtureFactories\Test\Factory\CountryFactory;
 use CakephpFixtureFactories\Test\Factory\CustomerFactory;
-use Exception;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
 use TestApp\Model\Entity\City;

--- a/tests/TestCase/Factory/FactoryAwareTraitUnitTest.php
+++ b/tests/TestCase/Factory/FactoryAwareTraitUnitTest.php
@@ -9,6 +9,7 @@ use CakephpTestSuiteLight\SkipTablesTruncation;
 
 class FactoryAwareTraitUnitTest extends TestCase
 {
+    use FactoryAwareTrait;
     use SkipTablesTruncation;
 
     public function getFactoryNamespaceData(): array
@@ -40,5 +41,28 @@ class FactoryAwareTraitUnitTest extends TestCase
     {
         $trait = $this->getObjectForTrait(FactoryAwareTrait::class);
         $this->assertEquals($expected, $trait->getFactoryClassName($name));
+    }
+
+    public function getFactoryNameData(): array
+    {
+        return [
+            ['Apples', 'AppleFactory', 'AppleFactory.php'],
+            ['apples', 'AppleFactory', 'AppleFactory.php'],
+            ['Apple', 'AppleFactory', 'AppleFactory.php'],
+            ['apple', 'AppleFactory', 'AppleFactory.php'],
+            ['pineApples', 'PineAppleFactory', 'PineAppleFactory.php'],
+            ['PineApples', 'PineAppleFactory', 'PineAppleFactory.php'],
+            ['pine_apples', 'PineAppleFactory', 'PineAppleFactory.php'],
+            ['pine_apple', 'PineAppleFactory', 'PineAppleFactory.php'],
+            ['Fruits/PineApple', 'Fruits\\PineAppleFactory', 'Fruits'.DIRECTORY_SEPARATOR.'PineAppleFactory.php'],
+            ['Food/Fruits/PineApple', 'Food\\Fruits\\PineAppleFactory', 'Food'.DIRECTORY_SEPARATOR.'Fruits'.DIRECTORY_SEPARATOR.'PineAppleFactory.php'],
+        ];
+    }
+
+    /** @dataProvider getFactoryNameData */
+    public function testGetFactoryNameFromModelName(string $name, string $factoryName, string $factoryFileName): void
+    {
+        $this->assertEquals($factoryName, $this->getFactoryNameFromModelName($name));
+        $this->assertEquals($factoryFileName, $this->getFactoryFileName($name));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -59,22 +59,9 @@ define('CONFIG', TEST_APP . 'config' . DS);
 
 require_once CORE_PATH . 'config/bootstrap.php';
 
-date_default_timezone_set('UTC');
-mb_internal_encoding('UTF-8');
-
 Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'TestApp',
-    'encoding' => 'UTF-8',
-    'base' => false,
-    'baseUrl' => false,
-    'dir' => APP_DIR,
-    'webroot' => 'webroot',
-    'wwwRoot' => WWW_ROOT,
-    'fullBaseUrl' => 'http://localhost',
-    'imageBaseUrl' => 'img/',
-    'jsBaseUrl' => 'js/',
-    'cssBaseUrl' => 'css/',
     'paths' => [
         'plugins' => [TEST_APP . 'plugins' . DS],
         'templates' => [
@@ -83,7 +70,6 @@ Configure::write('App', [
             TEMPLATE_PATH_CAKE_3,
             \Cake\Core\Plugin::templatePath('Bake'),
         ],
-        'locales' => [TEST_APP . 'resources' . DS . 'locales' . DS],
     ],
 ]);
 
@@ -150,45 +136,9 @@ $dbConnection = [
     ]
 ];
 
-ConnectionManager::setConfig('default', $dbConnection);
 ConnectionManager::setConfig('test', $dbConnection);
 $dbConnection['dummy_key'] = 'DummyKeyValue';
 ConnectionManager::setConfig('dummy', $dbConnection);
-
-Configure::write('Session', [
-    'defaults' => 'php',
-]);
-
-Log::setConfig([
-    // 'queries' => [
-    //     'className' => 'Console',
-    //     'stream' => 'php://stderr',
-    //     'scopes' => ['queriesLog']
-    // ],
-    'debug' => [
-        'engine' => 'Cake\Log\Engine\FileLog',
-        'levels' => ['notice', 'info', 'debug'],
-        'file' => 'debug',
-        'path' => LOGS,
-    ],
-    'error' => [
-        'engine' => 'Cake\Log\Engine\FileLog',
-        'levels' => ['warning', 'error', 'critical', 'alert', 'emergency'],
-        'file' => 'error',
-        'path' => LOGS,
-    ],
-]);
-
-Chronos::setTestNow(Chronos::now());
-Security::setSalt('a-long-but-not-random-value');
-
-//ini_set('intl.default_locale', 'en_US');
-//ini_set('session.gc_divisor', '1');
-
-// Fixate sessionid early on, as php7.2+
-// does not allow the sessionid to be set after stdout
-// has been written to.
-//session_id('cli');
 
 Inflector::rules('singular', ['/(ss)$/i' => '\1']);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
  */
 
 use Cake\Cache\Cache;
-use Cake\Chronos\Chronos;
 use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
-use Cake\Log\Log;
 use Cake\Utility\Inflector;
-use Cake\Utility\Security;
 use CakephpTestMigrator\Migrator;
 
 if (!defined('DS')) {


### PR DESCRIPTION
* Require cakephp/orm only
* Introduce a table without model
* Introduce the initialize method
* Removes the BaseFactory::getRootTableRegistry method
* Adds tests loading abstract association on the fly