### PR TITLE
set registryAlias on entity creation

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -282,7 +282,7 @@ class DataCompiler
             $data = $data($this->getFactory()->getFaker());
         }
         $entityClassName = $this->getFactory()->getTable()->getEntityClass();
-        $entity = new $entityClassName();
+        $entity = new $entityClassName([], ['source' => $this->getFactory()->getTable()->getRegistryAlias()]);
 
         return $this->patchEntity($entity, $data);
     }

--- a/tests/TestCase/Factory/DataCompilerTest.php
+++ b/tests/TestCase/Factory/DataCompilerTest.php
@@ -184,4 +184,10 @@ class DataCompilerTest extends TestCase
         $this->assertSame($author->prependPrefixToField($value), $author->get("field_with_setter_2"));
         $this->assertSame($author->prependPrefixToField($value), $author->get("field_with_setter_3"));
     }
+
+    public function testEntityHasRegistryAlias()
+    {
+        $country = CountryFactory::make()->getEntity();
+        $this->assertSame('Countries', $country->getSource());
+    }
 }


### PR DESCRIPTION
## What is was the problem?

As mentioned by Paul Hendriks in the slack channel today entities created by the fixture factory don't have a source set.

```
$entity = EntityFactory::make()->getEntity();
debug($entity->getSource);
```

The reason behind it was the fact, that the fixture factories don't create entities the same way as cake does internally.

See https://github.com/vierge-noire/cakephp-fixture-factories/blob/main/src/Factory/DataCompiler.php#L285
and https://github.com/cakephp/cakephp/blob/4.x/src/ORM/Table.php#L2714

This PR adjusts that so it behaves the same.