### PR TITLE
Enhancements to configuration: Grouped configuration settings & custom bake paths

### DIFF
--- a/docs/factories.md
+++ b/docs/factories.md
@@ -76,12 +76,12 @@ The factories will generate data in the locale of your application, if the latte
 Assuming your application namespace in `App`, factories should be placed in the `App\Test\Factory` namespace of your application.
 Or for a plugin Foo, in `Foo\Test\Factory`.
  
-You may change that by setting in your configuration the key `TestFixtureNamespace` to the desired namespace. E.g.
+You may change that by setting in your configuration the key `FixtureFactories.testFixtureNamespace` to the desired namespace. E.g.
 in `tests\bootstrap.php` or in the `setUp()` method of a test case:
 ```php
 use Cake\Core\Configure;
 
-Configure::write('TestFixtureNamespace', 'MyApp\Test\Factory');
+Configure::write('FixtureFactories.testFixtureNamespace', 'MyApp\Test\Factory');
 ```
 
 ## Setters
@@ -205,12 +205,12 @@ or per default in the factory's `setDefaultTemplate` method.
 Additionally, you can declare a behavior globally. This can be useful for behaviors that impact a large amount of tables
 and for which not nullable fields need to be populated.
 
-You may save in your configuration file, under the key `TestFixtureGlobalBehaviors`, all the behaviors that will be listened to, provided that the root table itself is listening to them.
+You may save in your configuration file, under the key `FixtureFactories.testFixtureGlobalBehaviors`, all the behaviors that will be listened to, provided that the root table itself is listening to them.
 
 ```php
 use Cake\Core\Configure;
 
-Configure::write('TestFixtureGlobalBehaviors', [
+Configure::write('FixtureFactories.testFixtureGlobalBehaviors', [
     'SomeBehaviorUsedInMultipleTables',
 ]);
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,6 +24,9 @@ protected function bootstrapCli(): void
 
 **We recommend using migrations for managing the schema of your test DB with the [CakePHP Migrator tool.](https://book.cakephp.org/migrations/2/en/index.html#using-migrations-for-tests)**
 
+## CakePHP 4.4+
+For CakePHP 4.4 or higher applications, add the `TruncateDirtyTables` trait to the top of your test classes to automatically truncate dirty tables after each test runs.
+No modification to your PHPUnit configuration is required when using the trait.
 
 ## CakePHP 3 or < 4.3
 For CakePHP anterior to 4.3 applications, you will need to use the [CakePHP test suite light plugin](https://github.com/vierge-noire/cakephp-test-suite-light#cakephp-test-suite-light)

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -110,10 +110,13 @@ class BakeFixtureFactoryCommand extends BakeCommand
      */
     public function getPath(Arguments $args): string
     {
+        $outputDir = Configure::read('FixtureFactories.testFixtureOutputDir', 'Factory/');
+        $outputDir = rtrim($outputDir, DS) . '/';
+
         if ($this->plugin) {
-            $path = $this->_pluginPath($this->plugin) . $this->pathFragment;
+            $path = $this->_pluginPath($this->plugin) . 'tests/' . $outputDir;
         } else {
-            $path = TESTS . 'Factory' . DS;
+            $path = TESTS . $outputDir;
         }
 
         return str_replace('/', DS, $path);

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -93,8 +93,6 @@ class BakeFixtureFactoryCommand extends BakeCommand
         } catch (\Exception $e) {
             $io->warning("The table $tableName could not be found... in " . $this->getModelPath());
             $io->abort($e->getMessage());
-
-            return false;
         }
 
         return $this;
@@ -265,8 +263,6 @@ class BakeFixtureFactoryCommand extends BakeCommand
 
         if (!$this->setTable($modelName, $io)) {
             $io->abort("$modelName not found...");
-
-            return self::CODE_SUCCESS;
         }
 
         $renderer = new TemplateRenderer('CakephpFixtureFactories');

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -31,19 +31,15 @@ class BakeFixtureFactoryCommand extends BakeCommand
     use FactoryAwareTrait;
 
     /**
-     * path to Factory directory
-     *
-     * @var string
-     */
-    public $pathFragment = 'tests' . DS . 'Factory' . DS;
-    /**
      * @var string path to the Table dir
      */
     public $pathToTableDir = 'Model' . DS . 'Table' . DS;
+
     /**
      * @var string
      */
     private $modelName;
+
     /**
      * @var \Cake\ORM\Table
      */

--- a/src/Command/SetupCommand.php
+++ b/src/Command/SetupCommand.php
@@ -78,8 +78,6 @@ class SetupCommand extends Command
 
         if (!file_exists($path)) {
             $io->abort("The phpunit config file $path could not be found.");
-
-            return '';
         } else {
             return $path;
         }

--- a/src/Factory/EventCollector.php
+++ b/src/Factory/EventCollector.php
@@ -134,7 +134,7 @@ class EventCollector
      */
     protected function setDefaultListeningBehaviors(): void
     {
-        $defaultBehaviors = (array)Configure::read('TestFixtureGlobalBehaviors', []);
+        $defaultBehaviors = (array)Configure::read('FixtureFactories.testFixtureGlobalBehaviors', []);
         $defaultBehaviors[] = 'Timestamp';
         $this->defaultListeningBehaviors = $defaultBehaviors;
         $this->listeningBehaviors = $defaultBehaviors;

--- a/src/Factory/FactoryAwareTrait.php
+++ b/src/Factory/FactoryAwareTrait.php
@@ -92,8 +92,8 @@ trait FactoryAwareTrait
      */
     public function getFactoryNamespace(?string $plugin = null): string
     {
-        if (Configure::check('TestFixtureNamespace')) {
-            return Configure::read('TestFixtureNamespace');
+        if (Configure::check('FixtureFactories.testFixtureNamespace')) {
+            return Configure::read('FixtureFactories.testFixtureNamespace');
         } else {
             return (
                 $plugin ?

--- a/src/ORM/FactoryTableLocator.php
+++ b/src/ORM/FactoryTableLocator.php
@@ -33,7 +33,7 @@ class FactoryTableLocator extends TableLocator
     {
         $table = parent::_create($options);
 
-        $defaultBehaviors = (array)Configure::read('TestFixtureGlobalBehaviors', []);
+        $defaultBehaviors = (array)Configure::read('FixtureFactories.testFixtureGlobalBehaviors', []);
         $defaultBehaviors[] = 'Timestamp';
 
         $behaviors = array_merge($options[EventCollector::MODEL_BEHAVIORS] ?? [], $defaultBehaviors);

--- a/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
+++ b/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
@@ -13,24 +13,26 @@ declare(strict_types=1);
  */
 namespace CakephpFixtureFactories\Test\TestCase\Command;
 
-use Cake\Console\Exception\StopException;
-use CakephpFixtureFactories\Command\BakeFixtureFactoryCommand;
-use CakephpFixtureFactories\Factory\BaseFactory;
-use CakephpFixtureFactories\Test\Util\TestCaseWithFixtureBaking;
+use Cake\Core\Configure;
+use Cake\Console\Arguments;
+use TestApp\Model\Entity\City;
+use TestApp\Model\Entity\Author;
 use TestApp\Model\Entity\Address;
 use TestApp\Model\Entity\Article;
-use TestApp\Model\Entity\Author;
-use TestApp\Model\Entity\City;
 use TestApp\Model\Entity\Country;
+use TestPlugin\Model\Entity\Bill;
+use TestApp\Test\Factory\CityFactory;
+use TestPlugin\Model\Entity\Customer;
+use TestApp\Test\Factory\AuthorFactory;
 use TestApp\Test\Factory\AddressFactory;
 use TestApp\Test\Factory\ArticleFactory;
-use TestApp\Test\Factory\AuthorFactory;
-use TestApp\Test\Factory\CityFactory;
 use TestApp\Test\Factory\CountryFactory;
-use TestPlugin\Model\Entity\Bill;
-use TestPlugin\Model\Entity\Customer;
 use TestPlugin\Test\Factory\BillFactory;
+use Cake\Console\Exception\StopException;
 use TestPlugin\Test\Factory\CustomerFactory;
+use CakephpFixtureFactories\Factory\BaseFactory;
+use CakephpFixtureFactories\Command\BakeFixtureFactoryCommand;
+use CakephpFixtureFactories\Test\Util\TestCaseWithFixtureBaking;
 
 /**
  * @see BakeFixtureFactoryCommand
@@ -61,6 +63,18 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
     {
         $name = 'Model';
         $this->assertSame('ModelFactory.php', $this->FactoryCommand->getFactoryFileName($name));
+    }
+
+    public function testGetPath()
+    {
+        $args = new Arguments([], [], []);
+
+        $path = $this->FactoryCommand->getPath($args);
+        Configure::write('FixtureFactories.testFixtureOutputDir', 'my/custom/path');
+        $customPath = $this->FactoryCommand->getPath($args);
+
+        $this->assertStringEndsWith('tests' . DS . 'TestApp' . DS . 'tests' . DS . 'Factory' . DS, $path);
+        $this->assertStringEndsWith('tests' . DS . 'TestApp' . DS . 'tests' . DS . 'my' . DS . 'custom' . DS . 'path' . DS, $customPath);
     }
 
     public function testGetTableListInApp()

--- a/tests/TestCase/Command/PersistCommandTest.php
+++ b/tests/TestCase/Command/PersistCommandTest.php
@@ -40,7 +40,7 @@ class PersistCommandTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public function setUp(): void

--- a/tests/TestCase/Factory/AssociationBuilderTest.php
+++ b/tests/TestCase/Factory/AssociationBuilderTest.php
@@ -30,12 +30,12 @@ class AssociationBuilderTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function testCheckAssociationWithCorrectAssociation()

--- a/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
+++ b/tests/TestCase/Factory/BaseFactoryAssociationsTest.php
@@ -42,12 +42,12 @@ class BaseFactoryAssociationsTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function testWithMultipleAssociations()

--- a/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
+++ b/tests/TestCase/Factory/BaseFactoryLoadAssociationsInInitializeTest.php
@@ -31,12 +31,12 @@ class BaseFactoryLoadAssociationsInInitializeTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function setUp(): void

--- a/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
+++ b/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
@@ -26,12 +26,12 @@ class BaseFactoryMakeWithEntityTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function dataProviderNoPersistOrPersist()

--- a/tests/TestCase/Factory/BaseFactoryUniqueEntitiesTest.php
+++ b/tests/TestCase/Factory/BaseFactoryUniqueEntitiesTest.php
@@ -30,12 +30,12 @@ class BaseFactoryUniqueEntitiesTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function testGetUniqueProperties()

--- a/tests/TestCase/Factory/EventCollectorTest.php
+++ b/tests/TestCase/Factory/EventCollectorTest.php
@@ -43,14 +43,14 @@ class EventCollectorTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
-        Configure::write('TestFixtureGlobalBehaviors', 'SomeBehaviorUsedInMultipleTables');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureGlobalBehaviors', 'SomeBehaviorUsedInMultipleTables');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
-        Configure::delete('TestFixtureGlobalBehaviors');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureGlobalBehaviors');
     }
 
     public function setUp(): void
@@ -64,7 +64,7 @@ class EventCollectorTest extends TestCase
 
     public function tearDown(): void
     {
-        Configure::delete('TestFixtureGlobalBehaviors');
+        Configure::delete('FixtureFactories.testFixtureGlobalBehaviors');
         unset($this->Countries);
 
         parent::tearDown();
@@ -75,7 +75,7 @@ class EventCollectorTest extends TestCase
      */
     public function testSetDefaultListeningBehaviors()
     {
-        Configure::write('TestFixtureGlobalBehaviors', ['Sluggable']);
+        Configure::write('FixtureFactories.testFixtureGlobalBehaviors', ['Sluggable']);
 
         $EventManager = new EventCollector('Foo');
 
@@ -258,7 +258,7 @@ class EventCollectorTest extends TestCase
         $this->assertNull($country->get($field));
 
         // The behavior should apply
-        Configure::write('TestFixtureGlobalBehaviors', ['SomePlugin']);
+        Configure::write('FixtureFactories.testFixtureGlobalBehaviors', ['SomePlugin']);
         $country = CountryFactory::make()->persist();
         $this->assertTrue($country->get($field));
     }

--- a/tests/TestCase/Factory/FactoryAwareTraitIntegrationTest.php
+++ b/tests/TestCase/Factory/FactoryAwareTraitIntegrationTest.php
@@ -17,12 +17,12 @@ class FactoryAwareTraitIntegrationTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function factoryFoundData(): array

--- a/tests/TestCase/Scenario/FixtureScenarioTest.php
+++ b/tests/TestCase/Scenario/FixtureScenarioTest.php
@@ -31,12 +31,12 @@ class FixtureScenarioTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        Configure::write('TestFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
+        Configure::write('FixtureFactories.testFixtureNamespace', 'CakephpFixtureFactories\Test\Factory');
     }
 
     public static function tearDownAfterClass(): void
     {
-        Configure::delete('TestFixtureNamespace');
+        Configure::delete('FixtureFactories.testFixtureNamespace');
     }
 
     public function scenarioNames(): array


### PR DESCRIPTION
References #178 

My app wants to bake the fixture factories into a separate directory than the default, only I found that that was not possible in the current plugin. This includes a patch to fix that (with tests). Users can now set `testFixtureOutputDir` to override the output directory where factories get baked.

**Secondarily, and very importantly,** all configuration settings for the plugin have been _namespaced_. This is something I brought up in my original feature ticket (linked above) and no one seemed to have a problem with it so I went for it. It is common practice for plugins to keep their configuration settings out of the global namespace, and so I have moved all configuration settings for this plugin to the `FixtureFactories` namespace:

```php
[
    'FixtureFactories' => [
        'testFixtureGlobalBehaviors' => [...],
        'testFixtureOutputDir' => 'my/output/dir',
    ],
]
```

The latter is **not** a backwards compatible change, so beware.