### PR TITLE
Factory::getEntityWithId()

### DIFF
--- a/src/Factory/BaseFactory.php
+++ b/src/Factory/BaseFactory.php
@@ -229,6 +229,20 @@ abstract class BaseFactory
     }
 
     /**
+     * Produce one entity from the present factory with primary key generated
+     *
+     * @return \Cake\Datasource\EntityInterface
+     */
+    public function getEntityWithId(): EntityInterface
+    {
+        $this->getDataCompiler()->startPersistMode();
+        $entity = $this->getEntity();
+        $this->getDataCompiler()->endPersistMode();
+
+        return $entity;
+    }
+
+    /**
      * Produce a set of entities from the present factory
      *
      * @return \Cake\Datasource\EntityInterface[]
@@ -236,6 +250,20 @@ abstract class BaseFactory
     public function getEntities(): array
     {
         return $this->toArray();
+    }
+
+    /**
+     * Produce a set of entities from the present factory with primary keys generated
+     *
+     * @return \Cake\Datasource\EntityInterface[]
+     */
+    public function getEntitiesWithId(): array
+    {
+        $this->getDataCompiler()->startPersistMode();
+        $entities = $this->getEntities();
+        $this->getDataCompiler()->endPersistMode();
+
+        return $entities;
     }
 
     /**

--- a/tests/TestCase/Factory/BaseFactoryTest.php
+++ b/tests/TestCase/Factory/BaseFactoryTest.php
@@ -871,4 +871,17 @@ class BaseFactoryTest extends TestCase
         $country = CountryFactory::make($n)->getEntities();
         $this->assertSame($n, count($country));
     }
+
+    public function testGetEntityWithId()
+    {
+        $country = CountryFactory::make()->getEntityWithId();
+        $this->assertGreaterThan(0, $country->id);
+    }
+
+    public function testGetEntitiesWithId()
+    {
+        $countries = CountryFactory::make(2)->getEntitiesWithId();
+        $this->assertGreaterThan(0, $countries[0]->id);
+        $this->assertGreaterThan(0, $countries[1]->id);
+    }
 }


### PR DESCRIPTION
In policy check, we often need to check if primary key is same or exists in an array 

```php
public function canUpdate(IdentityInterface $user, Article $article)
{
    return $user->id == $article->user_id;
}
```
This PR try to fill primary key even if it's not a `persist` call.
The second test (getEntitieswitId()` fail due to `DataCompiler::createPrimaryKeyOffset()` create only id on first entity but i really don't known why :(.