### PR TITLE
Added tinyinteger and smallinteger pk types

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -530,6 +530,12 @@ class DataCompiler
             case 'string':
                 $res = $this->getFactory()->getFaker()->uuid();
                 break;
+            case 'tinyinteger':
+                $res = mt_rand(0, intval('127'));
+                break;
+            case 'smallinteger':
+                $res = mt_rand(0, intval('32767'));
+                break;
             case 'biginteger':
                 $res = mt_rand(0, intval('9223372036854775807'));
                 break;


### PR DESCRIPTION
I've added two more primary key types, `tinyinteger` and  `smallinteger`.

I didn't add any tests as I don't see how they can be tested. The only useful test would be to see if the value doesn't exceed the type boundaries, but as the values are random... 

It seems useless to test that they are integers, as, If the primary key is not of string or uuid type, whatever the type is, it will alway fallback on integer any way.
