### PR TITLE
#216 ignore default associations when entity is injected

### DIFF
--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -195,7 +195,7 @@ class DataCompiler
         }
         $isEntityInjected = $injectedData instanceof EntityInterface;
         if ($isEntityInjected) {
-            /** @var EntityInterface */
+            /** @var \Cake\Datasource\EntityInterface $entity */
             $entity = $injectedData;
         } else {
             $entity = $this->getEntityFromDefaultTemplate();

--- a/src/Factory/DataCompiler.php
+++ b/src/Factory/DataCompiler.php
@@ -195,6 +195,7 @@ class DataCompiler
         }
         $isEntityInjected = $injectedData instanceof EntityInterface;
         if ($isEntityInjected) {
+            /** @var EntityInterface */
             $entity = $injectedData;
         } else {
             $entity = $this->getEntityFromDefaultTemplate();

--- a/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
+++ b/tests/TestCase/Factory/BaseFactoryMakeWithEntityTest.php
@@ -131,4 +131,12 @@ class BaseFactoryMakeWithEntityTest extends TestCase
         $this->assertSame($n * $m, count($authors));
         $this->assertSame($n, AuthorFactory::count());
     }
+
+    public function testMakeEntityWithoutDefaultAssociations()
+    {
+        $article1 = ArticleFactory::make()->persist();
+        $this->assertSame(ArticleFactory::DEFAULT_NUMBER_OF_AUTHORS, count($article1->authors));
+        $article2 = ArticleFactory::make($article1)->persist();
+        $this->assertSame(ArticleFactory::DEFAULT_NUMBER_OF_AUTHORS, count($article1->authors));
+    }
 }


### PR DESCRIPTION
Fix of https://github.com/vierge-noire/cakephp-fixture-factories/issues/216.

`DataCompiler::compileEntity()` should ignore both `$dataFromDefaultTemplate` and `$dataFromDefaultAssociations` when `EntityInterface` is injected.
