### PR TITLE
#218 fix phpdoc argument types of the with* methods inside bake factory template

### DIFF
--- a/templates/bake/fixture_factory.twig
+++ b/templates/bake/fixture_factory.twig
@@ -45,7 +45,7 @@ class {{ factory }} extends CakephpBaseFactory
 {% for association, associationFactory in toOne %}
 
     /**
-     * @param array|callable|null|int $parameter
+     * @param array|callable|null|int|\Cake\Datasource\EntityInterface|string $parameter
      * @return {{ factory }}
      */
     public function with{{ association }}($parameter = null): {{ factory }}
@@ -59,7 +59,7 @@ class {{ factory }} extends CakephpBaseFactory
 {% for association, associationFactory in oneToMany %}
 
     /**
-     * @param array|callable|null|int $parameter
+     * @param array|callable|null|int|\Cake\Datasource\EntityInterface|string $parameter
      * @param int $n
      * @return {{ factory }}
      */
@@ -74,7 +74,7 @@ class {{ factory }} extends CakephpBaseFactory
 {% for association, associationFactory in manyToMany %}
 
     /**
-     * @param array|callable|null|int $parameter
+     * @param array|callable|null|int|\Cake\Datasource\EntityInterface|string $parameter
      * @param int $n
      * @return {{ factory }}
      */


### PR DESCRIPTION
Related to https://github.com/vierge-noire/cakephp-fixture-factories/issues/218.

The arguments are passed into the `make()` methods of the `BaseFactory` subclasses. Added `EntityInterface` and `string` in phpdoc `@param` types.