### PR TITLE
Remove @internal from FactoryTableRegistry class

### DIFF
--- a/src/ORM/FactoryTableRegistry.php
+++ b/src/ORM/FactoryTableRegistry.php
@@ -30,8 +30,6 @@ use Cake\ORM\TableRegistry;
  * - Speeding up the fixture data injection to the database
  *
  * Class FactoryTableRegistry
- *
- * @internal
  */
 class FactoryTableRegistry extends TableRegistry
 {


### PR DESCRIPTION
There are times when package users needs to clear table registry, so it is better to not have `@internal` in the `FactoryTableRegistry` class.