### PR TITLE
cake5: use stable versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
     "license": "MIT",
     "require": {
         "php": ">=8.1",
-        "cakephp/orm": "5.x-dev",
+        "cakephp/orm": "^5.0",
         "fakerphp/faker": "^1.15",
         "vierge-noire/cakephp-test-suite-light": "dev-next"
     },
     "require-dev": {
-        "cakephp/bake": "3.x-dev as 3.0.0",
+        "cakephp/bake": "^3.0.0",
         "cakephp/cakephp-codesniffer": "^5.1",
-        "cakephp/migrations": "4.x-dev as 4.0.0",
-        "josegonzalez/dotenv": "dev-master",
+        "cakephp/migrations": "^4.0.0",
+        "josegonzalez/dotenv": "^4.0.0",
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^10.1",
         "vimeo/psalm": "^5.0"


### PR DESCRIPTION
Besides the `vierge-noire/cakephp-test-suite-light` of course