### PR TITLE
fix common options missing and warning

### DIFF
--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -324,7 +324,7 @@ class BakeFixtureFactoryCommand extends BakeCommand
             $data['useStatements'] = array_unique(array_values(Hash::flatten($useStatements)));
         }
 
-        if ($data['useStatements']) {
+        if (!empty($data['useStatements'])) {
             foreach ($data['useStatements'] as $index => $useStatement) {
                 $nameSpaceCheck = str_replace($data['namespace'] . '\\', '', $useStatement);
                 if (!str_contains($nameSpaceCheck, '\\')) {

--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -420,6 +420,8 @@ class BakeFixtureFactoryCommand extends BakeCommand
         $name = ($this->plugin ? $this->plugin . '.' : '') . $this->name;
         $parser = new ConsoleOptionParser($name);
 
+        $parser = $this->_setCommonOptions($parser);
+
         $parser->setDescription(
             'Fixture factory generator.'
         )

--- a/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
+++ b/tests/TestCase/Command/BakeFixtureFactoryCommandTest.php
@@ -343,4 +343,10 @@ class BakeFixtureFactoryCommandTest extends TestCaseWithFixtureBaking
 
         $this->assertSame($expected, $this->FactoryCommand->thisTableShouldBeBaked($model, $this->io));
     }
+
+    public function testCommandHasCommonOptions()
+    {
+        $options = $this->FactoryCommand->getOptionParser()->toArray();
+        $this->assertArrayHasKey('connection', $options['options']);
+    }
 }


### PR DESCRIPTION
See https://discourse.cakephp.org/t/connection-problem-with-fixture-factory-v3-0/11569

I didn't test baking a new factory 😅 

```
-> % cake bake fixture_factory Categories
2023-10-10 07:38:49 error: [TypeError] Cannot assign null to property Bake\Command\BakeCommand::$connection of type string in /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/bake/src/Utility/CommonOptionsTrait.php on line 77
Stack Trace:
- /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php:219
- /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/BaseCommand.php:192
- /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php:327
- /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php:168
- /Users/kevinpfeifer/Documents/Sunlime/alfred/bin/cake.php:12
- [main]:

[TypeError] Cannot assign null to property Bake\Command\BakeCommand::$connection of type string in /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/bake/src/Utility/CommonOptionsTrait.php on line 77

Stack Trace:

Bake\Command\BakeCommand->extractCommonProperties() - ROOT/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php, line 219
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->execute() - CORE/src/Console/BaseCommand.php, line 192
Cake\Console\BaseCommand->run() - CORE/src/Console/CommandRunner.php, line 327
Cake\Console\CommandRunner->runCommand() - CORE/src/Console/CommandRunner.php, line 168
Cake\Console\CommandRunner->run() - ROOT/bin/cake.php, line 12
[main] - [main], line 0
```

also there is another warning as well which this PR fixes

```
-> % cake bake fixture_factory Categories
2023-10-10 07:20:43 warning: Undefined array key "useStatements"
Trace:
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->templateData() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php, line 273
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->bakeFixtureFactory() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php, line 253
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->execute() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/BaseCommand.php, line 192
Cake\Console\BaseCommand->run() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php, line 327
Cake\Console\CommandRunner->runCommand() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php, line 168
Cake\Console\CommandRunner->run() /Users/kevinpfeifer/Documents/Sunlime/alfred/bin/cake.php, line 12
[main]

warning: 2 :: Undefined array key "useStatements" on line 327 of /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php
Stack Trace:

CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->templateData() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php, line 273
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->bakeFixtureFactory() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/vierge-noire/cakephp-fixture-factories/src/Command/BakeFixtureFactoryCommand.php, line 253
CakephpFixtureFactories\Command\BakeFixtureFactoryCommand->execute() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/BaseCommand.php, line 192
Cake\Console\BaseCommand->run() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php, line 327
Cake\Console\CommandRunner->runCommand() /Users/kevinpfeifer/Documents/Sunlime/alfred/vendor/cakephp/cakephp/src/Console/CommandRunner.php, line 168
Cake\Console\CommandRunner->run() /Users/kevinpfeifer/Documents/Sunlime/alfred/bin/cake.php, line 12
[main]
```