### PR TITLE
Add smart default data that is required by schema.

### DIFF
--- a/src/Command/BakeFixtureFactoryCommand.php
+++ b/src/Command/BakeFixtureFactoryCommand.php
@@ -51,12 +51,23 @@ class BakeFixtureFactoryCommand extends BakeCommand
     /**
      * @var array
      */
-    protected $map = [
+    protected array $map = [
         'string' => [
             'name' => 'name',
+            'first_name' => 'firstName',
+            'last_name' => 'lastName',
+            'username' => 'userName',
             'slug' => 'slug',
+            'email' => 'email',
             'description' => 'words',
             'postal_code' => 'postcode',
+            'city' => 'city',
+            'address' => 'address',
+            'url' => 'url',
+            'ip_address' => 'ipv4',
+            'currency' => 'currencyCode',
+            'phone_number' => 'phoneNumber',
+            'timezone' => 'timezone',
         ],
         'float' => [
             'latitude' => 'latitude',
@@ -589,7 +600,11 @@ class BakeFixtureFactoryCommand extends BakeCommand
         $keys = [];
 
         foreach ($associations as $association) {
-            $keys[] = $association->getForeignKey();
+            $key = $association->getForeignKey();
+            if ($key === false) {
+                continue;
+            }
+            $keys = array_merge($keys, (array)$key);
         }
 
         return $keys;

--- a/src/View/Helper/FactoryBakeHelper.php
+++ b/src/View/Helper/FactoryBakeHelper.php
@@ -14,8 +14,10 @@ class FactoryBakeHelper extends Helper
     public function defaultData(array $defaultData): string
     {
         $rows = [];
+        $indent = str_repeat(' ', 4 * 4);
+
         foreach ($defaultData as $key => $value) {
-            $rows[] = "\t\t\t\t" . '\'' . $key . '\' => ' . $value . ',';
+            $rows[] = $indent . '\'' . $key . '\' => ' . $value . ',';
         }
 
         $string = implode(PHP_EOL, $rows);

--- a/src/View/Helper/FactoryBakeHelper.php
+++ b/src/View/Helper/FactoryBakeHelper.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace CakephpFixtureFactories\View\Helper;
+
+use Cake\View\Helper;
+
+class FactoryBakeHelper extends Helper
+{
+    /**
+     * @param array $defaultData
+     * @return string
+     */
+    public function defaultData(array $defaultData): string
+    {
+        $rows = [];
+        foreach ($defaultData as $key => $value) {
+            $rows[] = "\t\t\t\t" . '\'' . $key . '\' => ' . $value . ',';
+        }
+
+        $string = implode(PHP_EOL, $rows);
+
+        $default = <<<TXT
+                // set the model's default values
+                // For example:
+                // 'name' => \$faker->lastName()
+TXT;
+
+        return ltrim($string ?: $default);
+    }
+}

--- a/templates/bake/fixture_factory.twig
+++ b/templates/bake/fixture_factory.twig
@@ -41,9 +41,7 @@ class {{ factory }} extends CakephpBaseFactory
     {
         $this->setDefaultData(function (Generator $faker) {
             return [
-                // set the model's default values
-                // For example:
-                // 'name' => $faker->lastName
+                {{ FactoryBake.defaultData(defaultData)|raw }}
             ];
         });
     }


### PR DESCRIPTION
Resolving https://github.com/vierge-noire/cakephp-fixture-factories/issues/241

The map is configurable by the end user, so they can add their own map of fields to faker.
I think we might want to make it more customizable, so that you can also pass params.
Otherwise, we can also use literals, and always verbosely add the full faker method call in to the map.

Smart model display field behavior could also be put into the configure map, maybe using _displayField as key.
This way people can also add their own there.

In my case it created

            return [
                'name' => $faker->name(),
                'shortdescription' => $faker->text(255),
                'created' => $faker->datetime(),
                'modified' => $faker->datetime(),
            ];
            
as those fields need to be filled (not null).