### PR TITLE
Fix up CS for array collections

### DIFF
--- a/templates/bake/fixture_factory.twig
+++ b/templates/bake/fixture_factory.twig
@@ -15,8 +15,8 @@ use {{ useStatement }};
  * {{ factory }}
  *
  * @method {{ entityClass }} getEntity()
- * @method {{ entityClass }}[] getEntities()
- * @method {{ entityClass }}|{{ entityClass }}[] persist()
+ * @method array<{{ entityClass }}> getEntities()
+ * @method {{ entityClass }}|array<{{ entityClass }}> persist()
  * @method static {{ entityClass }} get(mixed $primaryKey, array $options = [])
  */
 class {{ factory }} extends CakephpBaseFactory


### PR DESCRIPTION
Makes it not red in our CS when freshly baking:
 ```
 * @method \App\Model\Entity\Warehouse getEntity()
 * @method array<\App\Model\Entity\Warehouse> getEntities()
 * @method \App\Model\Entity\Warehouse|array<\App\Model\Entity\Warehouse> persist()
 ```