### PR TITLE
Improve compatibility with PHP 8.3

### DIFF
--- a/.github/workflows/tests_composer2.yml
+++ b/.github/workflows/tests_composer2.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
         db-type: [sqlite, mysql, pgsql]
         composer-type: [lowest, stable, dev]
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=8.1",
         "cakephp/orm": "^5.0",
-        "fakerphp/faker": "^1.15",
+        "fakerphp/faker": "^1.23",
         "vierge-noire/cakephp-test-suite-light": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Run tests on PHP 8.3 on CI
- Upgrade [fakerphp/faker version to ^1.23](https://github.com/FakerPHP/Faker/releases/tag/v1.23.1) to fix deprecation warnings
